### PR TITLE
Fixes pod install error

### DIFF
--- a/ios/RNWhatsAppStickers.podspec
+++ b/ios/RNWhatsAppStickers.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNWhatsAppStickers
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/Jobeso/react-native-whatsapp-stickers"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
```
Fetching podspec for `RNWhatsAppStickers` from `../node_modules/react-native-whatsapp-stickers/ios`
[!] The `RNWhatsAppStickers` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```